### PR TITLE
publication upgrade and impact statistics

### DIFF
--- a/assets/_typography.scss
+++ b/assets/_typography.scss
@@ -228,3 +228,8 @@ figcaption, .footnotes li {
   background-color: $yellow !important;
   color: $black;
 }
+
+/* special style used in templates */
+.pageTitle {
+  margin-bottom: 0;
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -90,8 +90,8 @@ body {
           background-color: $ytube-red;
         }
         .highlight.secondary {
-          background-color: $fbook-blue !important;
-          color: $white;
+          background-color: whitesmoke !important;
+          color: #606060;
         }
         .navbar-top {
             @include trex-navbar($white, $black, $red, $black);

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,8 +3,8 @@
 <header class="jumbotron">
     <div class="container">
         <div class="text-center">
-            <h1>{{ .Title }}</h1>
-            {{ if (isset .Params "subtitle") }}<h2 class="top light-font">{{ .Params.subtitle }}</h2>{{ end }}
+            <h1 class="pageTitle">{{ .Title }}</h1>
+            {{ if (isset .Params "subtitle") }}<smaller class="top light-font">{{ .Params.subtitle }}</smaller>{{ end }}
             <time class="post-date d-none" datetime='{{ .Date.Format "2006-01-02T15:04:05Z0700" }}'>{{ .Date.Format "Mon, Jan 2, 2006" }}</time>
         </div>
     </div>

--- a/layouts/c3app/single.html
+++ b/layouts/c3app/single.html
@@ -23,131 +23,16 @@
 <script src="/js/d3.min.js"></script>
 <script src="/js/c3.min.js"></script>
 <script src="/js/global.js"></script>
-<script>
-$(document).ready(function() {
 
-    var graphNodes = $('.c3graph');
-
-    const clist = [{
-        bindto: '#impression-graph',
-        data : { 
-            url: '/api/v2/statistics/impressions/day/15',
-            mimeType: 'json',
-            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
-            keys: { value : [ 'public', 'private', 'total' ], x: 'day' },
-            types: { 
-                'public': 'bar',
-                'private': 'bar',
-                'total': 'scatter'
-            },
-            groups: [ [ 'public', 'private' ] ], 
-            axes: {
-                'public': 'y',
-                'private': 'y',
-                'total': 'y',
-            },
-            colors: {
-                'public': '#3b5898',
-                'private': '#eee',
-                'total': 'black'
-            }
-        }, 
-        axis: {
-            x: {
-                type: 'timeseries',
-                tick: {
-                    format: '%d',
-                    culling: { max: 5 }
-                },
-
-            }
-        }
-    }, /* c3 */
-    {
-        bindto: '#timelines-graph',
-        data : { 
-            url: '/api/v2/statistics/timelines/day/15',
-            mimeType: 'json',
-            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
-            keys: { value : [ 'newsfeed', 'skipped' /*, 'total' */ ], x: 'day' },
-            types: { 
-                'newsfeed': 'bar',
-                'skipped': 'bar',
-                'total': 'scatter'
-            },
-            axes: {
-                'newsfeed': 'y',
-                'skipped': 'y',
-                'total': 'y',
-            },
-            colors: {
-                'newsfeed': '#3b5898',
-                'skipped': '#eee',
-                'total': 'black'
-            }
-        }, 
-        axis: {
-            x: {
-                type: 'timeseries',
-                tick: {
-                    format: '%d',
-                    culling: { max: 5 }
-                },
-
-            }
-        }
-    }, /* c3 */
-    {
-        bindto: '#processing-graph',
-        data : { 
-            url: '/api/v2/statistics/processing/day/15',
-            mimeType: 'json',
-            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
-            keys: { value : [ 'failure', 'successful', 'unprocessed', 'total' ], x: 'day' },
-            types: { 
-                'failure': 'bar',
-                'unprocessed': 'bar',
-                'successful': 'line',
-                'total': 'line',
-            },
-            axes: {
-                'failure': 'y',
-                'unprocessed': 'y',
-                'successful': 'y2',
-                'total': 'y2',
-            },
-            colors: {
-                'failure': 'black',
-                'unprocessed': '#eee',
-                'successful': '#3b5898',
-                'total': 'green'
-            }
-        }, 
-        axis: {
-            x: {
-                type: 'timeseries',
-                tick: {
-                    format: '%d',
-                    culling: { max: 5 }
-                },
-
-            },
-            y2: { show: true }
-        }
-    }, /* c3 */ ];
-
-    const graphs = _.map(graphNodes, function(graph) {
-        var graphId = '#' + graph.id;
-        var config = _.find(clist, { bindto: graphId });
-        if(config) {
-            console.log("Generating graph", graphId);
-            var r = c3.generate(config);
-        } else {
-            console.log("Invalid ID", graphId);
-        }
-    });
-
-});
-</script>
+<!-- include the site-script which hook at $(document).ready() to fire c3 -->
+{{ if eq site.Params.Subsite "youtube" }}
+    <script src="/js/youtube-c3-impact.js"></script>
+{{ else if eq site.Params.Subsite "facebook" }}
+    <script src="/js/facebook-c3-impact.js"></script>
+{{ else if eq site.Params.Subsite "pornhub" }}
+    <script src="/js/pornhub-c3-impact.js"></script>
+{{ else }}
+    <h1>UNSUPPORTED CONDITION IN c3app/single.html</h1>
+{{ end }}
 
 {{- end }}

--- a/layouts/c3app/single.html
+++ b/layouts/c3app/single.html
@@ -11,9 +11,6 @@
 </header>
 
 <div class="container">
-    <div id="piechart"></div>
-</div>
-<div class="container">
     {{ .Content }}
     <span class="clearfix"></span>
     {{ if .Params.include_partial }}
@@ -29,13 +26,15 @@
 <script>
 $(document).ready(function() {
 
-    const c = {
-        bindto: '#piechart',
+    var graphNodes = $('.c3graph');
+
+    const clist = [{
+        bindto: '#impression-graph',
         data : { 
-            url: 'http://localhost:8000/api/v2/statistics/impressions', // il problema è che non interpreta json
+            url: 'http://localhost:8000/api/v2/statistics/impressions/day/15',
             mimeType: 'json',
             xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
-            keys: { value : [ 'public', 'private', 'total' ], x: 'hour' },
+            keys: { value : [ 'public', 'private', 'total' ], x: 'day' },
             types: { 
                 'public': 'bar',
                 'private': 'bar',
@@ -46,21 +45,107 @@ $(document).ready(function() {
                 'public': 'y',
                 'private': 'y',
                 'total': 'y',
-            } 
+            },
+            colors: {
+                'public': '#3b5898',
+                'private': '#eee',
+                'total': 'black'
+            }
         }, 
         axis: {
             x: {
                 type: 'timeseries',
                 tick: {
-                    format: '%H:%M',
+                    format: '%d',
                     culling: { max: 5 }
                 },
 
             }
-        } 
-    };
+        }
+    }, /* c3 */
+    {
+        bindto: '#timelines-graph',
+        data : { 
+            url: 'http://localhost:8000/api/v2/statistics/timelines/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'newsfeed', 'skipped' /*, 'total' */ ], x: 'day' },
+            types: { 
+                'newsfeed': 'bar',
+                'skipped': 'bar',
+                'total': 'scatter'
+            },
+            axes: {
+                'newsfeed': 'y',
+                'skipped': 'y',
+                'total': 'y',
+            },
+            colors: {
+                'newsfeed': '#3b5898',
+                'skipped': '#eee',
+                'total': 'black'
+            }
+        }, 
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
 
-    var piechart = c3.generate(c);
+            }
+        }
+    }, /* c3 */
+    {
+        bindto: '#processing-graph',
+        data : { 
+            url: 'http://localhost:8000/api/v2/statistics/processing/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'failure', 'successful', 'unprocessed', 'total' ], x: 'day' },
+            types: { 
+                'failure': 'bar',
+                'unprocessed': 'bar',
+                'successful': 'line',
+                'total': 'line',
+            },
+            axes: {
+                'failure': 'y',
+                'unprocessed': 'y',
+                'successful': 'y2',
+                'total': 'y2',
+            },
+            colors: {
+                'failure': 'black',
+                'unprocessed': '#eee',
+                'successful': '#3b5898',
+                'total': 'green'
+            }
+        }, 
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
+
+            },
+            y2: { show: true }
+        }
+    }, /* c3 */ ];
+
+    const graphs = _.map(graphNodes, function(graph) {
+        var graphId = '#' + graph.id;
+        var config = _.find(clist, { bindto: graphId });
+        if(config) {
+            console.log("Generating graph", graphId);
+            var r = c3.generate(config);
+        } else {
+            console.log("Invalid ID", graphId);
+        }
+    });
 
 });
 </script>

--- a/layouts/c3app/single.html
+++ b/layouts/c3app/single.html
@@ -31,7 +31,7 @@ $(document).ready(function() {
     const clist = [{
         bindto: '#impression-graph',
         data : { 
-            url: 'http://localhost:8000/api/v2/statistics/impressions/day/15',
+            url: '/api/v2/statistics/impressions/day/15',
             mimeType: 'json',
             xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
             keys: { value : [ 'public', 'private', 'total' ], x: 'day' },
@@ -66,7 +66,7 @@ $(document).ready(function() {
     {
         bindto: '#timelines-graph',
         data : { 
-            url: 'http://localhost:8000/api/v2/statistics/timelines/day/15',
+            url: '/api/v2/statistics/timelines/day/15',
             mimeType: 'json',
             xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
             keys: { value : [ 'newsfeed', 'skipped' /*, 'total' */ ], x: 'day' },
@@ -100,7 +100,7 @@ $(document).ready(function() {
     {
         bindto: '#processing-graph',
         data : { 
-            url: 'http://localhost:8000/api/v2/statistics/processing/day/15',
+            url: '/api/v2/statistics/processing/day/15',
             mimeType: 'json',
             xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
             keys: { value : [ 'failure', 'successful', 'unprocessed', 'total' ], x: 'day' },

--- a/layouts/c3app/single.html
+++ b/layouts/c3app/single.html
@@ -1,0 +1,68 @@
+{{define "main" -}}
+
+<header class="jumbotron">
+    <div class="container">
+        <div class="text-center">
+            <h1>{{ .Title }}</h1>
+            {{ if (isset .Params "subtitle") }}<smaller class="top light-font">{{ .Params.subtitle }}</smaller>{{ end }}
+            <time class="post-date d-none" datetime='{{ .Date.Format "2006-01-02T15:04:05Z0700" }}'>{{ .Date.Format "Mon, Jan 2, 2006" }}</time>
+        </div>
+    </div>
+</header>
+
+<div class="container">
+    <div id="piechart"></div>
+</div>
+<div class="container">
+    {{ .Content }}
+    <span class="clearfix"></span>
+    {{ if .Params.include_partial }}
+        {{ partial .Params.include_partial . }}
+    {{ end }}
+    <span class="clearfix"></span>
+</div>
+
+<script src="/js/moment-with-locales.min.js"></script>
+<script src="/js/d3.min.js"></script>
+<script src="/js/c3.min.js"></script>
+<script src="/js/global.js"></script>
+<script>
+$(document).ready(function() {
+
+    const c = {
+        bindto: '#piechart',
+        data : { 
+            url: 'http://localhost:8000/api/v2/statistics/impressions', // il problema è che non interpreta json
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'public', 'private', 'total' ], x: 'hour' },
+            types: { 
+                'public': 'bar',
+                'private': 'bar',
+                'total': 'scatter'
+            },
+            groups: [ [ 'public', 'private' ] ], 
+            axes: {
+                'public': 'y',
+                'private': 'y',
+                'total': 'y',
+            } 
+        }, 
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%H:%M',
+                    culling: { max: 5 }
+                },
+
+            }
+        } 
+    };
+
+    var piechart = c3.generate(c);
+
+});
+</script>
+
+{{- end }}

--- a/layouts/shortcodes/resource.html
+++ b/layouts/shortcodes/resource.html
@@ -26,16 +26,16 @@
   </div>
   <div class="col-2">
     {{ $resources := .Get "resources" }}
-    {{ if $resources }}
-        <a href="{{ $resources }}"> TODO icon download</a>
-    {{ end }}
     <small><smaller>
-        link download material ? authors list ? information related TODO
+        {{ if $resources }}
+            {{ $resources }}
+        {{ end }}
     </smaller></small>
     <!-- note: why smaller + small do not make it tiny ? -->
+
     {{ $authors := .Get "authors" }}
     {{ if $authors }}
-        <small>{{ $authors }}</small>    
+        <small style="font-style:italic">{{ $authors }}</small>
     {{ end }}
   </div>
 

--- a/layouts/shortcodes/resource.html
+++ b/layouts/shortcodes/resource.html
@@ -1,0 +1,42 @@
+<div class="row" style="margin:0.5em">
+  {{ $title:= .Get "title" }}
+  {{ $when := .Get "when" }}
+  {{ $description := .Get "description" }}
+  {{ $href := .Get "href" }}
+  {{ $kind := .Get "kind" }}
+
+  <div class="col-1">
+      {{ if eq $kind "paper" }}
+          <small class="kindOfContent">Publication</small>
+      {{ else if eq $kind "link" }}
+          <small class="kindOfContent">link</small>
+      {{ else if eq $kind "event" }}
+          <small class="kindOfContent">event</small>
+      {{ else if eq $kind "video" }}
+          <small class="kindOfContent">video</small>
+      {{ end }}
+      <p>{{ $when }}
+  </div>
+
+  <div class="col-9" style="background:white">
+      <a href="{{ $href }}" target=_blank>
+          <h5>{{ $title }}</h5>
+          <small>{{ $description }}</small>
+      </a>
+  </div>
+  <div class="col-2">
+    {{ $resources := .Get "resources" }}
+    {{ if $resources }}
+        <a href="{{ $resources }}"> TODO icon download</a>
+    {{ end }}
+    <small><smaller>
+        link download material ? authors list ? information related TODO
+    </smaller></small>
+    <!-- note: why smaller + small do not make it tiny ? -->
+    {{ $authors := .Get "authors" }}
+    {{ if $authors }}
+        <small>{{ $authors }}</small>    
+    {{ end }}
+  </div>
+
+</div>

--- a/static/js/facebook-c3-impact.js
+++ b/static/js/facebook-c3-impact.js
@@ -1,0 +1,124 @@
+$(document).ready(function() {
+
+    var graphNodes = $('.c3graph');
+
+    const clist = [{
+        bindto: '#impression-graph',
+        data : {
+            url: '/api/v2/statistics/impressions/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'public', 'private', 'total' ], x: 'day' },
+            types: {
+                'public': 'bar',
+                'private': 'bar',
+                'total': 'scatter'
+            },
+            groups: [ [ 'public', 'private' ] ],
+            axes: {
+                'public': 'y',
+                'private': 'y',
+                'total': 'y',
+            },
+            colors: {
+                'public': '#3b5898',
+                'private': '#eee',
+                'total': 'black'
+            }
+        },
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
+
+            }
+        }
+    }, /* c3 */
+    {
+        bindto: '#timelines-graph',
+        data : {
+            url: '/api/v2/statistics/timelines/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'newsfeed', 'skipped' /*, 'total' */ ], x: 'day' },
+            types: {
+                'newsfeed': 'bar',
+                'skipped': 'bar',
+                'total': 'scatter'
+            },
+            axes: {
+                'newsfeed': 'y',
+                'skipped': 'y',
+                'total': 'y',
+            },
+            colors: {
+                'newsfeed': '#3b5898',
+                'skipped': '#eee',
+                'total': 'black'
+            }
+        },
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
+
+            }
+        }
+    }, /* c3 */
+    {
+        bindto: '#processing-graph',
+        data : {
+            url: '/api/v2/statistics/processing/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'failure', 'successful', 'unprocessed', 'total' ], x: 'day' },
+            types: {
+                'failure': 'bar',
+                'unprocessed': 'bar',
+                'successful': 'line',
+                'total': 'line',
+            },
+            axes: {
+                'failure': 'y',
+                'unprocessed': 'y',
+                'successful': 'y2',
+                'total': 'y2',
+            },
+            colors: {
+                'failure': 'black',
+                'unprocessed': '#eee',
+                'successful': '#3b5898',
+                'total': 'green'
+            }
+        },
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
+
+            },
+            y2: { show: true }
+        }
+    }, /* c3 */ ];
+
+    const graphs = _.map(graphNodes, function(graph) {
+        var graphId = '#' + graph.id;
+        var config = _.find(clist, { bindto: graphId });
+        if(config) {
+            console.log("Generating graph", graphId);
+            var r = c3.generate(config);
+        } else {
+            console.log("Invalid ID", graphId);
+        }
+    });
+
+});

--- a/static/js/youtube-c3-impact.js
+++ b/static/js/youtube-c3-impact.js
@@ -1,0 +1,111 @@
+$(document).ready(function() {
+
+    var graphNodes = $('.c3graph');
+
+    const clist = [{
+        bindto: '#supporters-graph',
+        data : {
+            url: '/api/v2/statistics/supporters/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'newcomers' ], x: 'day' },
+            type: 'bar',
+            axes: {
+                'newcomers': 'y'
+            },
+            colors: {
+                'newcomers': 'black'
+            }
+        },
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
+            }
+        }
+    }, /* c3 */
+    {
+        bindto: '#related-graph',
+        data : {
+            url: '/api/v2/statistics/related/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'total', 'related-20', 'related-19', 'related-1' ], x: 'day' },
+            types: {
+                'total': 'bar',
+                'related-20': 'bar',
+                'related-19': 'bar',
+                'related-1': 'bar'
+            },
+            axes: {
+                'total': 'y',
+                'related-20': 'y',
+                'related-19': 'y',
+                'related-1': 'y'
+            },
+        },
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
+
+            }
+        }
+    }, /* c3 */
+    {
+        bindto: '#processing-graph',
+        data : {
+            url: '/api/v2/statistics/processing/day/15',
+            mimeType: 'json',
+            xFormat: '%Y-%m-%dT%H:%M:%S.000Z',
+            keys: { value : [ 'failure', 'successful', 'unprocessed', 'total' ], x: 'day' },
+            types: {
+                'failure': 'bar',
+                'unprocessed': 'bar',
+                'successful': 'line',
+                'total': 'line',
+            },
+            axes: {
+                'failure': 'y',
+                'unprocessed': 'y',
+                'successful': 'y2',
+                'total': 'y2',
+            },
+            colors: {
+                'failure': 'black',
+                'unprocessed': '#eee',
+                'successful': '#3b5898',
+                'total': 'green'
+            }
+        },
+        axis: {
+            x: {
+                type: 'timeseries',
+                tick: {
+                    format: '%d',
+                    culling: { max: 5 }
+                },
+
+            },
+            y2: { show: true }
+        }
+    }, /* c3 */ ];
+
+    const graphs = _.map(graphNodes, function(graph) {
+        var graphId = '#' + graph.id;
+        var config = _.find(clist, { bindto: graphId });
+        if(config) {
+            console.log("Generating graph", graphId);
+            var r = c3.generate(config);
+        } else {
+            console.log("Invalid ID", graphId);
+        }
+    });
+
+});

--- a/static/js/youtube-c3-impact.js
+++ b/static/js/youtube-c3-impact.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
     var graphNodes = $('.c3graph');
 
     const clist = [{
-        bindto: '#supporters-graph',
+        bindto: '#newcomers-graph',
         data : {
             url: '/api/v2/statistics/supporters/day/15',
             mimeType: 'json',

--- a/theme.toml
+++ b/theme.toml
@@ -3,13 +3,13 @@
 
 name = "trex"
 license = "AGPLv3"
-licenselink = "https://github.com/tracking-exposed/trex/blob/master/LICENSE"
+licenselink = "https://github.com/tracking-exposed/hugo-theme-trex/blob/master/LICENSE"
 description = ""
 homepage = "https://tracking.exposed"
 tags = []
 features = []
-min_version = "0.41"
+min_version = "0.55"
 
 [author]
-  name = "LC.D"
-  homepage = "https://cataldi.design/en/"
+  name = "Various Trackingg Exposed contributors"
+  homepage = "https://tracking.exposed/contributors"


### PR DESCRIPTION
In this pull request few file have been added. They are used by the branch facebook.tracking.exposed (and this pull request https://github.com/tracking-exposed/facebook.tracking.exposed/pull/10 )

This branch contains:
* a new style to upgrade the publication and analysis (not very pretty I guess, but enough to iterate on it)
* c3js graphs about stats, they work with API v2 (implemented in testing.tracking.exposed)