### PR TITLE
Removed the exaggerated 'monthly' div font-size property

### DIFF
--- a/layouts/monthly/single.html
+++ b/layouts/monthly/single.html
@@ -10,7 +10,7 @@
     </div>
 </header>
 
-<div class="container" style="font-size:4em;">
+<div class="container">
     {{ .Content }}
     <span class="clearfix"></span>
 </div>


### PR DESCRIPTION
Stupid OCD fix for monthly reports like the [Autumn](https://tracking.exposed/monthly/autumn-2019/) and [September](https://tracking.exposed/monthly/september-2019/) ones.